### PR TITLE
Adding TFHD flag for DEFAULT_BASE_IS_MOOF needed for MSE 

### DIFF
--- a/crates/bmff/src/lib.rs
+++ b/crates/bmff/src/lib.rs
@@ -1655,6 +1655,7 @@ pub struct TrackFragmentHeaderBox {
     pub default_sample_duration: Option<u32>,
     pub default_sample_size: Option<u32>,
     pub default_sample_flags: Option<DefaultSampleFlags>,
+    pub default_base_is_moof: bool,
 }
 
 bitflags! {
@@ -1665,6 +1666,7 @@ bitflags! {
         const DEFAULT_SAMPLE_SIZE_PRESENT = 0x00_0010;
         const DEFAULT_SAMPLE_FLAGS_PRESENT = 0x00_0020;
         const DURATION_IS_EMPTY = 0x01_0000;
+        const DEFAULT_BASE_IS_MOOF = 0x02_0000;
     }
 }
 
@@ -1725,6 +1727,9 @@ impl FullBox for TrackFragmentHeaderBox {
         }
         if self.default_sample_flags.is_some() {
             flags |= TrackFragmentHeaderFlags::DEFAULT_SAMPLE_FLAGS_PRESENT;
+        }
+        if self.default_base_is_moof {
+            flags |= TrackFragmentHeaderFlags::DEFAULT_BASE_IS_MOOF;
         }
         let flags = flags.bits().to_be_bytes();
         [flags[1], flags[2], flags[3]]

--- a/crates/mp4-stream/src/lib.rs
+++ b/crates/mp4-stream/src/lib.rs
@@ -287,6 +287,7 @@ impl MediaSegment {
                         #[allow(clippy::unwrap_used)] // infallible
                         Some(DefaultSampleFlags::from_bits(0x0101_0000).unwrap())
                     }, // not I-frame
+                    default_base_is_moof: false,
                 },
                 trun: vec![TrackFragmentRunBox {
                     data_offset: Some(0),


### PR DESCRIPTION
Hello, I've been working on a video project, and your library has helped me immensely! Thanks for making it!

Part of my project is serving segments for use with DASH.js, which uses the browser's video tags' Media Source Extensions (MSE) to stream segments. I encode the same video multiple times at different bitrates as well.

I found that I could play complete files (init segment + 1 or more media segments) with `vlc` from the same encoded set, but I couldn't reorder media segments, or use higher or lower bitrate versions of the same media segment due to the base data offset being different for variants of the same media segment. However, I found that MSE actually requires a flag to be set that overrides the base data offset to be the start of the `moof`, which is what mp4-stream sets it to anyway. (See https://w3c.github.io/mse-byte-stream-format-isobmff/ where it talks about `default-base-is-moof`).

I added this flag into the `bmff` library, and things started working between different encoded sets! I believe that this should be useful to anyone using the `bmff` library for DASH or MSE streaming, so I made this pull request.

I only changed `mp4-stream` to set this flag to `false`, so that it doesn't change the current way that the `mp4-stream` library or the `pet-monitor-app` binary functions.